### PR TITLE
 CASSANDRA-6091 – Better Vnode support in hadoop/pig

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Add ability to limit number of native connections (CASSANDRA-8086)
  * Add offline tool to relevel sstables (CASSANDRA-8301)
  * Preserve stream ID for more protocol errors (CASSANDRA-8848)
  * Fix combining token() function with multi-column relations on

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,7 +19,8 @@
  * Add batch remove iterator to ABSC (CASSANDRA-8414, 8666)
  * Fix isClientMode check in Keyspace (CASSANDRA-8687)
  * 'nodetool info' prints exception against older node (CASSANDRA-8796)
-
+ * Ensure SSTableSimpleUnsortedWriter.close() terminates if
+   disk writer has crashed (CASSANDRA-8807)
 
 2.0.12:
  * Use more efficient slice size for querying internal secondary

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 2.0.13:
+ * Fix combining token() function with multi-column relations on
+   clustering columns (CASSANDRA-8797)
  * Make CFS.markReferenced() resistant to bad refcounting (CASSANDRA-8829)
  * Fix StreamTransferTask abort/complete bad refcounting (CASSANDRA-8815)
  * Fix AssertionError when querying a DESC clustering ordered

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Make CFS.markReferenced() resistant to bad refcounting (CASSANDRA-8829)
  * Fix StreamTransferTask abort/complete bad refcounting (CASSANDRA-8815)
  * Fix AssertionError when querying a DESC clustering ordered
    table with ASC ordering and paging (CASSANDRA-8767)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 2.0.13:
+ * Fix regression in mixed single and multi-column relation support for
+   SELECT statements (CASSANDRA-8613)
  * Add ability to limit number of native connections (CASSANDRA-8086)
  * Add offline tool to relevel sstables (CASSANDRA-8301)
  * Preserve stream ID for more protocol errors (CASSANDRA-8848)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Fix StreamTransferTask abort/complete bad refcounting (CASSANDRA-8815)
  * Fix AssertionError when querying a DESC clustering ordered
    table with ASC ordering and paging (CASSANDRA-8767)
  * AssertionError: "Memory was freed" when running cleanup (CASSANDRA-8716)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@
  * 'nodetool info' prints exception against older node (CASSANDRA-8796)
  * Ensure SSTableSimpleUnsortedWriter.close() terminates if
    disk writer has crashed (CASSANDRA-8807)
+ * Fix CQLSSTableWriter throwing exception and spawning threads
+   (CASSANDRA-8808)
 
 2.0.12:
  * Use more efficient slice size for querying internal secondary

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Add offline tool to relevel sstables (CASSANDRA-8301)
  * Preserve stream ID for more protocol errors (CASSANDRA-8848)
  * Fix combining token() function with multi-column relations on
    clustering columns (CASSANDRA-8797)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 2.0.13:
+ * Fix AssertionError when querying a DESC clustering ordered
+   table with ASC ordering and paging (CASSANDRA-8767)
  * AssertionError: "Memory was freed" when running cleanup (CASSANDRA-8716)
  * Make it possible to set max_sstable_age to fractional days (CASSANDRA-8406)
  * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate() (CASSANDRA-8748)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate() (CASSANDRA-8748)
  * Fix some multi-column relations with indexes on some clustering
    columns (CASSANDRA-8275)
  * Fix IllegalArgumentException in dynamic snitch (CASSANDRA-8448)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 2.0.14:
+ * Provide better exceptions for invalid replication strategy parameters
+   (CASSANDRA-8909)
  * Fix regression in mixed single and multi-column relation support for
    SELECT statements (CASSANDRA-8613)
  * Add ability to limit number of native connections (CASSANDRA-8086)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,12 @@
-2.0.13:
+2.0.14:
  * Fix regression in mixed single and multi-column relation support for
    SELECT statements (CASSANDRA-8613)
  * Add ability to limit number of native connections (CASSANDRA-8086)
+ * Fix CQLSSTableWriter throwing exception and spawning threads
+   (CASSANDRA-8808)
+
+
+2.0.13:
  * Add offline tool to relevel sstables (CASSANDRA-8301)
  * Preserve stream ID for more protocol errors (CASSANDRA-8848)
  * Fix combining token() function with multi-column relations on
@@ -29,8 +34,7 @@
  * 'nodetool info' prints exception against older node (CASSANDRA-8796)
  * Ensure SSTableSimpleUnsortedWriter.close() terminates if
    disk writer has crashed (CASSANDRA-8807)
- * Fix CQLSSTableWriter throwing exception and spawning threads
-   (CASSANDRA-8808)
+
 
 2.0.12:
  * Use more efficient slice size for querying internal secondary

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * AssertionError: "Memory was freed" when running cleanup (CASSANDRA-8716)
  * Make it possible to set max_sstable_age to fractional days (CASSANDRA-8406)
  * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate() (CASSANDRA-8748)
  * Fix some multi-column relations with indexes on some clustering

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Preserve stream ID for more protocol errors (CASSANDRA-8848)
  * Fix combining token() function with multi-column relations on
    clustering columns (CASSANDRA-8797)
  * Make CFS.markReferenced() resistant to bad refcounting (CASSANDRA-8829)
@@ -7,7 +8,8 @@
    table with ASC ordering and paging (CASSANDRA-8767)
  * AssertionError: "Memory was freed" when running cleanup (CASSANDRA-8716)
  * Make it possible to set max_sstable_age to fractional days (CASSANDRA-8406)
- * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate() (CASSANDRA-8748)
+ * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate()
+   (CASSANDRA-8748)
  * Fix some multi-column relations with indexes on some clustering
    columns (CASSANDRA-8275)
  * Fix IllegalArgumentException in dynamic snitch (CASSANDRA-8448)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.14:
+ * Expose commit log archive status via JMX (CASSANDRA-8734)
  * Provide better exceptions for invalid replication strategy parameters
    (CASSANDRA-8909)
  * Fix regression in mixed single and multi-column relation support for

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.13:
+ * Make it possible to set max_sstable_age to fractional days (CASSANDRA-8406)
  * Fix memory leak in SSTableSimple*Writer and SSTableReader.validate() (CASSANDRA-8748)
  * Fix some multi-column relations with indexes on some clustering
    columns (CASSANDRA-8275)

--- a/build.xml
+++ b/build.xml
@@ -1101,6 +1101,9 @@
     </testmacro>
   </target>
 
+  <!-- Use this with an FQDN for test class, and a csv list of methods like this:
+    ant testsome -Dtest.name=org.apache.cassandra.service.StorageServiceServerTest -Dtest.methods=testRegularMode,testGetAllRangesEmpty
+  -->
   <target name="testsome" depends="build-test" description="Execute specific unit tests" >
     <testmacro suitename="unit" inputdir="${test.unit.src}" exclude="**/pig/*.java" timeout="${test.timeout}">
       <test name="${test.name}" methods="${test.methods}"/>

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -332,6 +332,14 @@ native_transport_port: 9042
 # be rejected as invalid. The default is 256MB.
 # native_transport_max_frame_size_in_mb: 256
 
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
 # Whether to start the thrift rpc server.
 start_rpc: true
 

--- a/conf/commitlog_archiving.properties
+++ b/conf/commitlog_archiving.properties
@@ -27,7 +27,7 @@
 # Command to execute to archive a commitlog segment
 # Parameters: %path => Fully qualified path of the segment to archive
 #             %name => Name of the commit log.
-# Example: archive_command=/bin/ln %path /backup/%name
+# Example: archive_command=/bin/cp -f %path /backup/%name
 #
 # Limitation: *_command= expects one command with arguments. STDOUT
 # and STDIN or multiple commands cannot be executed.  You might want
@@ -37,7 +37,7 @@ archive_command=
 # Command to execute to make an archived commitlog live again.
 # Parameters: %from is the full path to an archived commitlog segment (from restore_directories)
 #             %to is the live commitlog directory
-# Example: restore_command=cp -f %from %to
+# Example: restore_command=/bin/cp -f %from %to
 restore_command=
 
 # Directory to scan the recovery files in.

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -131,6 +131,8 @@ CQL supports _prepared statements_. Prepared statement is an optimization that a
 
 In a statement, each time a column value is expected (in the data manipulation and query statements), a @<variable>@ (see above) can be used instead. A statement with bind variables must then be _prepared_. Once it has been prepared, it can executed by providing concrete values for the bind variables. The exact procedure to prepare a statement and execute a prepared statement depends on the CQL driver used and is beyond the scope of this document.
 
+In addition to providing column values, bind markers may be used to provide values for @LIMIT@, @TIMESTAMP@, and @TTL@ clauses.  If anonymous bind markers are used, the names for the query parameters will be @[limit]@, @[timestamp]@, and @[ttl]@, respectively.
+
 
 h2(#dataDefinition). Data Definition
 

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -194,7 +194,7 @@ ALTER KEYSPACE Excelsior
           WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 4};
 
 p. 
-The @ALTER KEYSPACE@ statement alter the properties of an existing keyspace. The supported @<properties>@ are the same that for the "@CREATE TABLE@":#createKeyspaceStmt statement.
+The @ALTER KEYSPACE@ statement alters the properties of an existing keyspace. The supported @<properties>@ are the same as for the "@CREATE KEYSPACE@":#createKeyspaceStmt statement.
 
 
 h3(#dropKeyspaceStmt). DROP KEYSPACE

--- a/doc/native_protocol_v1.spec
+++ b/doc/native_protocol_v1.spec
@@ -34,7 +34,7 @@ Table of Contents
         4.2.5.5. Schema_change
       4.2.6. EVENT
   5. Compression
-  6. Collection types
+  6. Data Type Serialization Formats
   7. Error codes
 
 
@@ -169,8 +169,8 @@ Table of Contents
   To describe the layout of the frame body for the messages in Section 4, we
   define the following:
 
-    [int]          A 4 bytes integer
-    [short]        A 2 bytes unsigned integer
+    [int]          A 4 byte integer
+    [short]        A 2 byte unsigned integer
     [string]       A [short] n, followed by n bytes representing an UTF-8
                    string.
     [long string]  An [int] n, followed by n bytes representing an UTF-8 string.
@@ -525,22 +525,124 @@ Table of Contents
   flag (see Section 2.2) is set.
 
 
-6. Collection types
+6. Data Type Serialization Formats
 
-  This section describe the serialization format for the collection types:
-  list, map and set. This serialization format is both useful to decode values
-  returned in RESULT messages but also to encode values for EXECUTE ones.
+  This sections describes the serialization formats for all CQL data types
+  supported by Cassandra through the native protocol.  These serialization
+  formats should be used by client drivers to encode values for EXECUTE
+  messages.  Cassandra will use these formats when returning values in
+  RESULT messages.
 
-  The serialization formats are:
-     List: a [short] n indicating the size of the list, followed by n elements.
-           Each element is [short bytes] representing the serialized element
-           value.
-     Map: a [short] n indicating the size of the map, followed by n entries.
-          Each entry is composed of two [short bytes] representing the key and
-          the value of the entry map.
-     Set: a [short] n indicating the size of the set, followed by n elements.
-          Each element is [short bytes] representing the serialized element
-          value.
+  All values are represented as [bytes] in EXECUTE and RESULT messages.
+  The [bytes] format includes an int prefix denoting the length of the value.
+  For that reason, the serialization formats described here will not include
+  a length component.
+
+  For legacy compatibility reasons, note that most non-string types support
+  "empty" values (i.e. a value with zero length).  An empty value is distinct
+  from NULL, which is encoded with a negative length.
+
+  As with the rest of the native protocol, all encodings are big-endian.
+
+6.1. ascii
+
+  A sequence of bytes in the ASCII range [0, 127].  Bytes with values outside of
+  this range will result in a validation error.
+
+6.2 bigint
+
+  An eight-byte two's complement integer.
+
+6.3 blob
+
+  Any sequence of bytes.
+
+6.4 boolean
+
+  A single byte.  A value of 0 denotes "false"; any other value denotes "true".
+  (However, it is recommended that a value of 1 be used to represent "true".)
+
+6.5 decimal
+
+  The decimal format represents an arbitrary-precision number.  It contains an
+  [int] "scale" component followed by a varint encoding (see section 6.17)
+  of the unscaled value.  The encoded value represents "<unscaled>E<-scale>".
+  In other words, "<unscaled> * 10 ^ (-1 * <scale>)".
+
+6.6 double
+
+  An eight-byte floating point number in the IEEE 754 binary64 format.
+
+6.7 float
+
+  An four-byte floating point number in the IEEE 754 binary32 format.
+
+6.8 inet
+
+  A 4 byte or 16 byte sequence denoting an IPv4 or IPv6 address, respectively.
+
+6.9 int
+
+  A four-byte two's complement integer.
+
+6.10 list
+
+  A [short] n indicating the number of elements in the list, followed by n
+  elements.  Each element is [short bytes] representing the serialized value.
+
+6.11 map
+
+  A [short] n indicating the number of key/value pairs in the map, followed by
+  n entries.  Each entry is composed of two [short bytes] representing the key
+  and value.
+
+6.12 set
+
+  A [short] n indicating the number of elements in the set, followed by n
+  elements.  Each element is [short bytes] representing the serialized value.
+
+6.13 text
+
+  A sequence of bytes conforming to the UTF-8 specifications.
+
+6.14 timestamp
+
+  An eight-byte two's complement integer representing a millisecond-precision
+  offset from the unix epoch (00:00:00, January 1st, 1970).  Negative values
+  represent a negative offset from the epoch.
+
+6.15 uuid
+
+  A 16 byte sequence representing any valid UUID as defined by RFC 4122.
+
+6.16 varchar
+
+  An alias of the "text" type.
+
+6.17 varint
+
+  A variable-length two's complement encoding of a signed integer.
+
+  The following examples may help implementors of this spec:
+
+  Value | Encoding
+  ------|---------
+      0 |     0x00
+      1 |     0x01
+    127 |     0x7F
+    128 |   0x0080
+     -1 |     0xFF
+   -128 |     0x80
+   -129 |   0xFF7F
+
+  Note that positive numbers must use a most-significant byte with a value
+  less than 0x80, because a most-significant bit of 1 indicates a negative
+  value.  Implementors should pad positive values that have a MSB >= 0x80
+  with a leading 0x00 byte.
+
+6.18 timeuuid
+
+  A 16 byte sequence representing a version 1 UUID as defined by RFC 4122.
 
 
 7. Error codes

--- a/doc/native_protocol_v1.spec
+++ b/doc/native_protocol_v1.spec
@@ -486,8 +486,8 @@ Table of Contents
       Currently, events are sent when new nodes are added to the cluster, and
       when nodes are removed. The body of the message (after the event type)
       consists of a [string] and an [inet], corresponding respectively to the
-      type of change ("NEW_NODE" or "REMOVED_NODE") followed by the address of
-      the new/removed node.
+      type of change ("NEW_NODE", "REMOVED_NODE", or "MOVED_NODE") followed
+      by the address of the new/removed/moved node.
     - "STATUS_CHANGE": events related to change of node status. Currently,
       up/down events are sent. The body of the message (after the event type)
       consists of a [string] and an [inet], corresponding respectively to the
@@ -509,6 +509,9 @@ Table of Contents
   should be enough), otherwise they may experience a connection refusal at
   first.
 
+  It is possible for the same event to be sent multiple times. Therefore,
+  a client library should ignore the same event if it has already been notified
+  of a change.
 
 5. Compression
 

--- a/doc/native_protocol_v2.spec
+++ b/doc/native_protocol_v2.spec
@@ -37,7 +37,7 @@ Table of Contents
       4.2.7. AUTH_CHALLENGE
       4.2.8. AUTH_SUCCESS
   5. Compression
-  6. Collection types
+  6. Data Type Serialization Formats
   7. Result paging
   8. Error codes
   9. Changes from v1
@@ -186,8 +186,8 @@ Table of Contents
   To describe the layout of the frame body for the messages in Section 4, we
   define the following:
 
-    [int]          A 4 bytes integer
-    [short]        A 2 bytes unsigned integer
+    [int]          A 4 byte integer
+    [short]        A 2 byte unsigned integer
     [string]       A [short] n, followed by n bytes representing an UTF-8
                    string.
     [long string]  An [int] n, followed by n bytes representing an UTF-8 string.
@@ -673,22 +673,125 @@ Table of Contents
       avaivable on some installation.
 
 
-6. Collection types
+6. Data Type Serialization Formats
 
-  This section describe the serialization format for the collection types:
-  list, map and set. This serialization format is both useful to decode values
-  returned in RESULT messages but also to encode values for EXECUTE ones.
+  This sections describes the serialization formats for all CQL data types
+  supported by Cassandra through the native protocol.  These serialization
+  formats should be used by client drivers to encode values for EXECUTE
+  messages.  Cassandra will use these formats when returning values in
+  RESULT messages.
 
-  The serialization formats are:
-     List: a [short] n indicating the size of the list, followed by n elements.
-           Each element is [short bytes] representing the serialized element
-           value.
-     Map: a [short] n indicating the size of the map, followed by n entries.
-          Each entry is composed of two [short bytes] representing the key and
-          the value of the entry map.
-     Set: a [short] n indicating the size of the set, followed by n elements.
-          Each element is [short bytes] representing the serialized element
-          value.
+  All values are represented as [bytes] in EXECUTE and RESULT messages.
+  The [bytes] format includes an int prefix denoting the length of the value.
+  For that reason, the serialization formats described here will not include
+  a length component.
+
+  For legacy compatibility reasons, note that most non-string types support
+  "empty" values (i.e. a value with zero length).  An empty value is distinct
+  from NULL, which is encoded with a negative length.
+
+  As with the rest of the native protocol, all encodings are big-endian.
+
+6.1. ascii
+
+  A sequence of bytes in the ASCII range [0, 127].  Bytes with values outside of
+  this range will result in a validation error.
+
+6.2 bigint
+
+  An eight-byte two's complement integer.
+
+6.3 blob
+
+  Any sequence of bytes.
+
+6.4 boolean
+
+  A single byte.  A value of 0 denotes "false"; any other value denotes "true".
+  (However, it is recommended that a value of 1 be used to represent "true".)
+
+6.5 decimal
+
+  The decimal format represents an arbitrary-precision number.  It contains an
+  [int] "scale" component followed by a varint encoding (see section 6.17)
+  of the unscaled value.  The encoded value represents "<unscaled>E<-scale>".
+  In other words, "<unscaled> * 10 ^ (-1 * <scale>)".
+
+6.6 double
+
+  An eight-byte floating point number in the IEEE 754 binary64 format.
+
+6.7 float
+
+  An four-byte floating point number in the IEEE 754 binary32 format.
+
+6.8 inet
+
+  A 4 byte or 16 byte sequence denoting an IPv4 or IPv6 address, respectively.
+
+6.9 int
+
+  A four-byte two's complement integer.
+
+6.10 list
+
+  A [short] n indicating the number of elements in the list, followed by n
+  elements.  Each element is [short bytes] representing the serialized value.
+
+6.11 map
+
+  A [short] n indicating the number of key/value pairs in the map, followed by
+  n entries.  Each entry is composed of two [short bytes] representing the key
+  and value.
+
+6.12 set
+
+  A [short] n indicating the number of elements in the set, followed by n
+  elements.  Each element is [short bytes] representing the serialized value.
+
+6.13 text
+
+  A sequence of bytes conforming to the UTF-8 specifications.
+
+6.14 timestamp
+
+  An eight-byte two's complement integer representing a millisecond-precision
+  offset from the unix epoch (00:00:00, January 1st, 1970).  Negative values
+  represent a negative offset from the epoch.
+
+6.15 uuid
+
+  A 16 byte sequence representing any valid UUID as defined by RFC 4122.
+
+6.16 varchar
+
+  An alias of the "text" type.
+
+6.17 varint
+
+  A variable-length two's complement encoding of a signed integer.
+
+  The following examples may help implementors of this spec:
+
+  Value | Encoding
+  ------|---------
+      0 |     0x00
+      1 |     0x01
+    127 |     0x7F
+    128 |   0x0080
+    129 |   0x0081
+     -1 |     0xFF
+   -128 |     0x80
+   -129 |   0xFF7F
+
+  Note that positive numbers must use a most-significant byte with a value
+  less than 0x80, because a most-significant bit of 1 indicates a negative
+  value.  Implementors should pad positive values that have a MSB >= 0x80
+  with a leading 0x00 byte.
+
+6.18 timeuuid
+
+  A 16 byte sequence representing a version 1 UUID as defined by RFC 4122.
 
 
 7. Result paging

--- a/doc/native_protocol_v2.spec
+++ b/doc/native_protocol_v2.spec
@@ -604,8 +604,8 @@ Table of Contents
       Currently, events are sent when new nodes are added to the cluster, and
       when nodes are removed. The body of the message (after the event type)
       consists of a [string] and an [inet], corresponding respectively to the
-      type of change ("NEW_NODE" or "REMOVED_NODE") followed by the address of
-      the new/removed node.
+      type of change ("NEW_NODE", "REMOVED_NODE", or "MOVED_NODE") followed
+      by the address of the new/removed/moved node.
     - "STATUS_CHANGE": events related to change of node status. Currently,
       up/down events are sent. The body of the message (after the event type)
       consists of a [string] and an [inet], corresponding respectively to the
@@ -626,6 +626,10 @@ Table of Contents
   advise to wait a short time before trying to connect to the node (1 seconds
   should be enough), otherwise they may experience a connection refusal at
   first.
+
+  It is possible for the same event to be sent multiple times. Therefore,
+  a client library should ignore the same event if it has already been notified
+  of a change.
 
 4.2.7. AUTH_CHALLENGE
 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -112,6 +112,8 @@ public class Config
     public Integer native_transport_port = 9042;
     public Integer native_transport_max_threads = 128;
     public Integer native_transport_max_frame_size_in_mb = 256;
+    public volatile Long native_transport_max_concurrent_connections = -1L;
+    public volatile Long native_transport_max_concurrent_connections_per_ip = -1L;
 
     @Deprecated
     public Integer thrift_max_message_length_in_mb = 16;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1108,6 +1108,25 @@ public class DatabaseDescriptor
         return conf.native_transport_max_frame_size_in_mb * 1024 * 1024;
     }
 
+    public static Long getNativeTransportMaxConcurrentConnections()
+    {
+        return conf.native_transport_max_concurrent_connections;
+    }
+
+    public static void setNativeTransportMaxConcurrentConnections(long nativeTransportMaxConcurrentConnections)
+    {
+        conf.native_transport_max_concurrent_connections = nativeTransportMaxConcurrentConnections;
+    }
+
+    public static Long getNativeTransportMaxConcurrentConnectionsPerIp() {
+        return conf.native_transport_max_concurrent_connections_per_ip;
+    }
+
+    public static void setNativeTransportMaxConcurrentConnectionsPerIp(long native_transport_max_concurrent_connections_per_ip)
+    {
+        conf.native_transport_max_concurrent_connections_per_ip = native_transport_max_concurrent_connections_per_ip;
+    }
+
     public static double getCommitLogSyncBatchWindow()
     {
         return conf.commitlog_sync_batch_window_in_ms;

--- a/src/java/org/apache/cassandra/cql3/Cql.g
+++ b/src/java/org/apache/cassandra/cql3/Cql.g
@@ -355,6 +355,7 @@ usingClauseObjective[Attributes.Raw attrs]
  * USING TIMESTAMP <long>
  * SET name1 = value1, name2 = value2
  * WHERE key = value;
+ * [IF (EXISTS | name = value, ...)];
  */
 updateStatement returns [UpdateStatement.ParsedUpdate expr]
     @init {

--- a/src/java/org/apache/cassandra/cql3/Relation.java
+++ b/src/java/org/apache/cassandra/cql3/Relation.java
@@ -54,4 +54,9 @@ public abstract class Relation {
     }
 
     public abstract boolean isMultiColumn();
+
+    public boolean isOnToken()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -84,6 +84,11 @@ public class SingleColumnRelation extends Relation
         return false;
     }
 
+    public boolean isOnToken()
+    {
+        return onToken;
+    }
+
     public SingleColumnRelation withNonStrictOperator()
     {
         switch (relationType)

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1906,8 +1906,12 @@ public class SelectStatement implements CQLStatement, MeasurableForPreparedCache
             Iterator<Name> iter = Iterators.cycle(cfDef.partitionKeys());
             for (Relation relation : whereClause)
             {
+                if (!relation.isOnToken())
+                    continue;
+
+                assert !relation.isMultiColumn() : "Unexpectedly got multi-column token relation";
                 SingleColumnRelation singleColumnRelation = (SingleColumnRelation) relation;
-                if (singleColumnRelation.onToken && !cfDef.get(singleColumnRelation.getEntity().prepare(cfDef.cfm)).equals(iter.next()))
+                if (!cfDef.get(singleColumnRelation.getEntity().prepare(cfDef.cfm)).equals(iter.next()))
                     throw new InvalidRequestException(String.format("The token function arguments must be in the partition key order: %s",
                                                                     Joiner.on(',').join(cfDef.partitionKeys())));
             }

--- a/src/java/org/apache/cassandra/db/ColumnFamily.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamily.java
@@ -74,7 +74,12 @@ public abstract class ColumnFamily implements Iterable<Column>, IRowCacheEntry
 
     public ColumnFamily cloneMeShallow()
     {
-        return cloneMeShallow(getFactory(), isInsertReversed());
+        return cloneMeShallow(false);
+    }
+
+    public ColumnFamily cloneMeShallow(boolean reversed)
+    {
+        return cloneMeShallow(getFactory(), reversed);
     }
 
     public ColumnFamilyType getType()

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -299,6 +299,36 @@ public class CommitLog implements CommitLogMBean
         return metrics.totalCommitLogSize.value();
     }
 
+    @Override
+    public String getArchiveCommand()
+    {
+        return archiver.archiveCommand;
+    }
+
+    @Override
+    public String getRestoreCommand()
+    {
+        return archiver.restoreCommand;
+    }
+
+    @Override
+    public String getRestoreDirectories()
+    {
+        return archiver.restoreDirectories;
+    }
+
+    @Override
+    public long getRestorePointInTime()
+    {
+        return archiver.restorePointInTime;
+    }
+
+    @Override
+    public String getRestorePrecision()
+    {
+        return archiver.precision.toString();
+    }
+
     /**
      * Fetches a new segment file from the allocator and activates it.
      *

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
@@ -53,9 +53,9 @@ public class CommitLogArchiver
 
     public final Map<String, Future<?>> archivePending = new ConcurrentHashMap<String, Future<?>>();
     public final ExecutorService executor = new JMXEnabledThreadPoolExecutor("commitlog_archiver");
-    private final String archiveCommand;
-    private final String restoreCommand;
-    private final String restoreDirectories;
+    final String archiveCommand;
+    final String restoreCommand;
+    final String restoreDirectories;
     public final long restorePointInTime;
     public final TimeUnit precision;
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
@@ -45,6 +45,37 @@ public interface CommitLogMBean
     public long getTotalCommitlogSize();
 
     /**
+     *  Command to execute to archive a commitlog segment.  Blank to disabled.
+     */
+    public String getArchiveCommand();
+
+    /**
+     * Command to execute to make an archived commitlog live again
+     */
+    public String getRestoreCommand();
+
+    /**
+     * Directory to scan the recovery files in
+     */
+    public String getRestoreDirectories();
+
+    /**
+     * Restore mutations created up to and including this timestamp in GMT
+     * Format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+     *
+     * Recovery will continue through the segment when the first client-supplied
+     * timestamp greater than this time is encountered, but only mutations less than
+     * or equal to this timestamp will be applied.
+     */
+    public long getRestorePointInTime();
+
+    /**
+     * get precision of the timestamp used in the restore (MILLISECONDS, MICROSECONDS, ...)
+     * to determine if passed the restore point in time.
+     */
+    public String getRestorePrecision();
+
+    /**
      * Recover a single file.
      */
     public void recover(String path) throws IOException;

--- a/src/java/org/apache/cassandra/hadoop/ColumnFamilyRecordReader.java
+++ b/src/java/org/apache/cassandra/hadoop/ColumnFamilyRecordReader.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.TypeParser;
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.thrift.*;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
@@ -212,6 +214,7 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
 
     private abstract class RowIterator extends AbstractIterator<Pair<ByteBuffer, SortedMap<ByteBuffer, Column>>>
     {
+        protected final Iterator<Range<Token>> tokenRanges = split.getTokenRanges().iterator();
         protected List<KeySlice> rows;
         protected int totalRead = 0;
         protected final boolean isSuper;
@@ -329,6 +332,7 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
     private class StaticRowIterator extends RowIterator
     {
         protected int i = 0;
+        private Range<Token> range = tokenRanges.next();
 
         private void maybeInit()
         {
@@ -336,26 +340,25 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
             if (rows != null && i < rows.size())
                 return;
 
-            String startToken;
-            if (totalRead == 0)
-            {
-                // first request
-                startToken = split.getStartToken();
-            }
-            else
+            String startToken = partitioner.getTokenFactory().toString(range.left);
+            String endToken = partitioner.getTokenFactory().toString(range.right);
+            if (rows != null && totalRead != 0)
             {
                 startToken = partitioner.getTokenFactory().toString(partitioner.getToken(Iterables.getLast(rows).key));
-                if (startToken.equals(split.getEndToken()))
+                if (startToken.equals(endToken))
                 {
-                    // reached end of the split
                     rows = null;
-                    return;
+                    if (tokenRanges.hasNext())
+                        range = tokenRanges.next();
+                    else
+                        // reached end of the split
+                        return;
                 }
             }
 
             KeyRange keyRange = new KeyRange(batchSize)
                                 .setStart_token(startToken)
-                                .setEnd_token(split.getEndToken())
+                                .setEnd_token(endToken)
                                 .setRow_filter(filter);
             try
             {
@@ -365,6 +368,11 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
                 if (rows.isEmpty())
                 {
                     rows = null;
+                    if (tokenRanges.hasNext())
+                    {
+                        range = tokenRanges.next();
+                        maybeInit();
+                    }
                     return;
                 }
 
@@ -422,6 +430,7 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
 
     private class WideRowIterator extends RowIterator
     {
+        private Range<Token> range = tokenRanges.next();
         private PeekingIterator<Pair<ByteBuffer, SortedMap<ByteBuffer, Column>>> wideColumns;
         private ByteBuffer lastColumn = ByteBufferUtil.EMPTY_BYTE_BUFFER;
         private ByteBuffer lastCountedKey = ByteBufferUtil.EMPTY_BYTE_BUFFER;
@@ -431,13 +440,13 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
             if (wideColumns != null && wideColumns.hasNext())
                 return;
 
+            Token.TokenFactory factory = partitioner.getTokenFactory();
             KeyRange keyRange;
-            if (totalRead == 0)
+            if (rows == null || totalRead == 0)
             {
-                String startToken = split.getStartToken();
                 keyRange = new KeyRange(batchSize)
-                          .setStart_token(startToken)
-                          .setEnd_token(split.getEndToken())
+                          .setStart_token(factory.toString(range.left))
+                          .setEnd_token(factory.toString(range.right))
                           .setRow_filter(filter);
             }
             else
@@ -446,7 +455,7 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
                 logger.debug("Starting with last-seen row {}", lastRow.key);
                 keyRange = new KeyRange(batchSize)
                           .setStart_key(lastRow.key)
-                          .setEnd_token(split.getEndToken())
+                          .setEnd_token(factory.toString(range.right))
                           .setRow_filter(filter);
             }
 
@@ -463,7 +472,14 @@ public class ColumnFamilyRecordReader extends RecordReader<ByteBuffer, SortedMap
                 if (wideColumns.hasNext() && wideColumns.peek().right.keySet().iterator().next().equals(lastColumn))
                     wideColumns.next();
                 if (!wideColumns.hasNext())
+                {
                     rows = null;
+                    if (tokenRanges.hasNext())
+                    {
+                        range = tokenRanges.next();
+                        maybeInit();
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/src/java/org/apache/cassandra/hadoop/ColumnFamilySplit.java
+++ b/src/java/org/apache/cassandra/hadoop/ColumnFamilySplit.java
@@ -17,45 +17,47 @@
  */
 package org.apache.cassandra.hadoop;
 
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.InputSplit;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.utils.FBUtilities;
+
+
 
 public class ColumnFamilySplit extends InputSplit implements Writable, org.apache.hadoop.mapred.InputSplit
 {
-    private String startToken;
-    private String endToken;
+    private List<Range<Token>> tokenRanges;
     private long length;
     private String[] dataNodes;
+    private String partitionerClassname;
 
-    @Deprecated
-    public ColumnFamilySplit(String startToken, String endToken, String[] dataNodes)
+    public ColumnFamilySplit(List<Range<Token>> tokenRanges, long length, String[] dataNodes, String partitionerClassname)
     {
-        this(startToken, endToken, Long.MAX_VALUE, dataNodes);
-    }
-
-    public ColumnFamilySplit(String startToken, String endToken, long length, String[] dataNodes)
-    {
-        assert startToken != null;
-        assert endToken != null;
-        this.startToken = startToken;
-        this.endToken = endToken;
+        assert !tokenRanges.isEmpty();
+        for (Range<Token> range : tokenRanges)
+        {
+            assert range.left != null;
+            assert range.right != null;
+        }
+        this.tokenRanges = tokenRanges;
         this.length = length;
         this.dataNodes = dataNodes;
+        this.partitionerClassname = partitionerClassname;
     }
 
-    public String getStartToken()
+    public List<Range<Token>> getTokenRanges()
     {
-        return startToken;
-    }
-
-    public String getEndToken()
-    {
-        return endToken;
+        return tokenRanges;
     }
 
     // getLength and getLocations satisfy the InputSplit abstraction
@@ -77,34 +79,68 @@ public class ColumnFamilySplit extends InputSplit implements Writable, org.apach
     // KeyspaceSplits as needed by the Writable interface.
     public void write(DataOutput out) throws IOException
     {
-        out.writeUTF(startToken);
-        out.writeUTF(endToken);
-        out.writeInt(dataNodes.length);
-        for (String endpoint : dataNodes)
+        out.writeUTF(partitionerClassname);
+        out.writeLong(length);
+        out.writeInt(tokenRanges.size());
+        try
         {
-            out.writeUTF(endpoint);
+            Token.TokenFactory factory = FBUtilities.newPartitioner(partitionerClassname).getTokenFactory();
+            for (Range<Token> range : tokenRanges)
+            {
+                out.writeUTF(factory.toString(range.left));
+                out.writeUTF(factory.toString(range.right));
+            }
+            out.writeInt(dataNodes.length);
+            for (String endpoint : dataNodes)
+                out.writeUTF(endpoint);
+        }
+        catch (ConfigurationException ex)
+        {
+            throw new IOException(ex);
         }
     }
 
     public void readFields(DataInput in) throws IOException
     {
-        startToken = in.readUTF();
-        endToken = in.readUTF();
-        int numOfEndpoints = in.readInt();
-        dataNodes = new String[numOfEndpoints];
-        for(int i = 0; i < numOfEndpoints; i++)
+        partitionerClassname = in.readUTF();
+        length = in.readLong();
+        int tokenRangeSize = in.readInt();
+        tokenRanges = new ArrayList<>();
+        try
         {
-            dataNodes[i] = in.readUTF();
+            IPartitioner partitioner = FBUtilities.newPartitioner(partitionerClassname);
+            Token.TokenFactory factory = partitioner.getTokenFactory();
+            for (int i = 0 ; i < tokenRangeSize ; ++i)
+                tokenRanges.add(new Range<>(factory.fromString(in.readUTF()), factory.fromString(in.readUTF()), partitioner));
+
+            int numOfEndpoints = in.readInt();
+            dataNodes = new String[numOfEndpoints];
+            for(int i = 0; i < numOfEndpoints; i++)
+                dataNodes[i] = in.readUTF();
+        }
+        catch (ConfigurationException ex)
+        {
+            throw new IOException(ex);
         }
     }
 
     @Override
     public String toString()
     {
-        return "ColumnFamilySplit(" +
-               "(" + startToken
-               + ", '" + endToken + ']'
-               + " @" + (dataNodes == null ? null : Arrays.asList(dataNodes)) + ')';
+        StringBuilder sb = new StringBuilder("ColumnFamilySplit([");
+        for (Range<Token> range : tokenRanges)
+            sb.append("(").append(range.left).append(", '").append(range.right).append("],");
+
+        sb.setLength(sb.length()-1);
+        sb.append("] @");
+        if (null != dataNodes)
+        {
+            for (String dataNode : dataNodes)
+                sb.append(dataNode).append(',');
+
+            sb.setLength(sb.length()-1);
+        }
+        return sb.append(')').toString();
     }
 
     public static ColumnFamilySplit read(DataInput in) throws IOException

--- a/src/java/org/apache/cassandra/hadoop/cql3/CqlRecordReader.java
+++ b/src/java/org/apache/cassandra/hadoop/cql3/CqlRecordReader.java
@@ -26,7 +26,6 @@ import java.util.*;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
@@ -41,6 +40,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.hadoop.ColumnFamilySplit;
 import org.apache.cassandra.hadoop.ConfigHelper;
 import org.apache.cassandra.utils.Pair;
@@ -52,9 +53,12 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+
 /**
  * CqlRecordReader reads the rows return from the CQL query
  * It uses CQL auto-paging.
@@ -109,7 +113,6 @@ public class CqlRecordReader extends RecordReader<Long, Row>
         partitioner = ConfigHelper.getInputPartitioner(conf);
         inputColumns = CqlConfigHelper.getInputcolumns(conf);
         userDefinedWhereClauses = CqlConfigHelper.getInputWhereClauses(conf);
-        Optional<Integer> pageRowSizeOptional = CqlConfigHelper.getInputPageRowSize(conf);
 
         try
         {
@@ -247,11 +250,40 @@ public class CqlRecordReader extends RecordReader<Long, Row>
 
         public RowIterator()
         {
-            AbstractType type = partitioner.getTokenValidator();
-            ResultSet rs = session.execute(cqlQuery, type.compose(type.fromString(split.getStartToken())), type.compose(type.fromString(split.getEndToken())) );
-            for (ColumnMetadata meta : cluster.getMetadata().getKeyspace(quote(keyspace)).getTable(quote(cfName)).getPartitionKey())
-                partitionBoundColumns.put(meta.getName(), Boolean.TRUE);
-            rows = rs.iterator();
+            final Token.TokenFactory factory = partitioner.getTokenFactory();
+            final AbstractType type = partitioner.getTokenValidator();
+            rows = new Iterator<Row>()
+            {
+                protected final Iterator<Range<Token>> tokenRanges = split.getTokenRanges().iterator();
+                protected Iterator<Row> rangeRows = Collections.emptyIterator();
+                public boolean hasNext()
+                {
+                    while (!rangeRows.hasNext() && tokenRanges.hasNext())
+                    {
+                        Range<Token> range = tokenRanges.next();
+                        Object startToken = type.compose(factory.toByteArray(range.left));
+                        Object endToken = type.compose(factory.toByteArray(range.right));
+                        ResultSet rs = session.execute(cqlQuery, startToken, endToken);
+                        if (partitionBoundColumns.isEmpty())
+                        {
+                            KeyspaceMetadata keyspaceMeta = cluster.getMetadata().getKeyspace(quote(keyspace));
+                            TableMetadata tableMeta = keyspaceMeta.getTable(quote(cfName));
+                            for (ColumnMetadata meta : tableMeta.getPartitionKey())
+                                partitionBoundColumns.put(meta.getName(), Boolean.TRUE);
+                        }
+                        rangeRows = rs.iterator();
+                    }
+                    return rangeRows.hasNext();
+                }
+                public Row next()
+                {
+                    return rangeRows.next();
+                }
+                public void remove()
+                {
+                    throw new UnsupportedOperationException("remove");
+                }
+            };
         }
 
         protected Pair<Long, Row> computeNext()

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -37,9 +37,9 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RequestValidationException;
-import org.apache.cassandra.io.compress.CompressionParameters;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.utils.Allocator;
@@ -77,6 +77,11 @@ import org.apache.cassandra.utils.Pair;
  */
 public class CQLSSTableWriter implements Closeable
 {
+    static
+    {
+        Config.setClientMode(true);
+    }
+
     private final AbstractSSTableSimpleWriter writer;
     private final UpdateStatement insert;
     private final List<ColumnSpecification> boundNames;
@@ -215,7 +220,7 @@ public class CQLSSTableWriter implements Closeable
             {
                 if (writer.currentKey() == null || !key.equals(writer.currentKey().key))
                     writer.newRow(key);
-                insert.addUpdateForKey(writer.currentColumnFamily(), key, clusteringPrefix, params);
+                insert.addUpdateForKey(writer.currentColumnFamily(), key, clusteringPrefix, params, false);
             }
             return this;
         }
@@ -345,19 +350,11 @@ public class CQLSSTableWriter implements Closeable
                     KSMetaData ksm = Schema.instance.getKSMetaData(this.schema.ksName);
                     if (ksm == null)
                     {
-                        ksm = KSMetaData.newKeyspace(this.schema.ksName,
-                                AbstractReplicationStrategy.getClass("org.apache.cassandra.locator.SimpleStrategy"),
-                                ImmutableMap.of("replication_factor", "1"),
-                                true,
-                                Collections.singleton(this.schema));
-                        Schema.instance.load(ksm);
+                        createKeyspaceWithColumnFamily(this.schema);
                     }
                     else if (Schema.instance.getCFMetaData(this.schema.ksName, this.schema.cfName) == null)
                     {
-                        Schema.instance.load(this.schema);
-                        ksm = KSMetaData.cloneWith(ksm, Iterables.concat(ksm.cfMetaData().values(), Collections.singleton(this.schema)));
-                        Schema.instance.setKeyspaceDefinition(ksm);
-                        Keyspace.open(ksm.name).initCf(this.schema.cfId, this.schema.cfName, false);
+                        addColumnFamilyToKeyspace(ksm, this.schema);
                     }
                     return this;
                 }
@@ -366,6 +363,35 @@ public class CQLSSTableWriter implements Closeable
             {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
+        }
+
+        /**
+         * Adds the specified column family to the specified keyspace.
+         *
+         * @param ksm the keyspace meta data
+         * @param cfm the column family meta data
+         */
+        private static void addColumnFamilyToKeyspace(KSMetaData ksm, CFMetaData cfm)
+        {
+            ksm = KSMetaData.cloneWith(ksm, Iterables.concat(ksm.cfMetaData().values(), Collections.singleton(cfm)));
+            Schema.instance.load(cfm);
+            Schema.instance.setKeyspaceDefinition(ksm);
+        }
+
+        /**
+         * Creates a keyspace for the specified column family.
+         *
+         * @param cfm the column family
+         * @throws ConfigurationException if a problem occurs while creating the keyspace.
+         */
+        private static void createKeyspaceWithColumnFamily(CFMetaData cfm) throws ConfigurationException
+        {
+            KSMetaData ksm = KSMetaData.newKeyspace(cfm.ksName,
+                                                    AbstractReplicationStrategy.getClass("org.apache.cassandra.locator.SimpleStrategy"),
+                                                    ImmutableMap.of("replication_factor", "1"),
+                                                    true,
+                                                    Collections.singleton(cfm));
+            Schema.instance.load(ksm);
         }
 
         /**

--- a/src/java/org/apache/cassandra/io/sstable/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableReader.java
@@ -593,7 +593,10 @@ public class SSTableReader extends SSTable implements Closeable
     private void validate()
     {
         if (this.first.compareTo(this.last) > 0)
+        {
+            releaseReference();
             throw new IllegalStateException(String.format("SSTable first key %s > last key %s", this.first, this.last));
+        }
     }
 
     /** get the position in the index file to start scanning to find the given key (at most indexInterval keys away) */

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -227,7 +227,7 @@ public class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
                             throw new AssertionError("Empty partition");
                         first = false;
                     }
-                    writer.close();
+                    writer.close(true);
                 }
             }
             catch (Throwable e)

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -72,7 +72,7 @@ public class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
         {
             if (currentKey != null)
                 writeRow(currentKey, columnFamily);
-            writer.close();
+            writer.close(true);
         }
         catch (FSError e)
         {

--- a/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java
@@ -363,11 +363,18 @@ public class SSTableWriter extends SSTable
         return sstable;
     }
 
-    // Close the writer and return the descriptor to the new sstable and it's metadata
     public Pair<Descriptor, SSTableMetadata> close()
+    {
+        return close(false);
+    }
+
+    // Close the writer and return the descriptor to the new sstable and it's metadata
+    public Pair<Descriptor, SSTableMetadata> close(boolean closeBf)
     {
         // index and filter
         iwriter.close();
+        if (closeBf)
+            iwriter.bf.close();
         // main data, close will truncate if necessary
         dataFile.close();
         // write sstable statistics

--- a/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
+++ b/src/java/org/apache/cassandra/locator/AbstractReplicationStrategy.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.locator;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.util.*;
 
@@ -237,6 +238,11 @@ public abstract class AbstractReplicationStrategy
         {
             Constructor<? extends AbstractReplicationStrategy> constructor = strategyClass.getConstructor(parameterTypes);
             strategy = constructor.newInstance(keyspaceName, tokenMetadata, snitch, strategyOptions);
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable targetException = e.getTargetException();
+            throw new ConfigurationException(targetException.getMessage(), targetException);
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2125,9 +2125,15 @@ public class StorageProxy implements StorageProxyMBean
 
     public Long getTruncateRpcTimeout() { return DatabaseDescriptor.getTruncateRpcTimeout(); }
     public void setTruncateRpcTimeout(Long timeoutInMillis) { DatabaseDescriptor.setTruncateRpcTimeout(timeoutInMillis); }
+
+    public Long getNativeTransportMaxConcurrentConnections() { return DatabaseDescriptor.getNativeTransportMaxConcurrentConnections(); }
+    public void setNativeTransportMaxConcurrentConnections(Long nativeTransportMaxConcurrentConnections) { DatabaseDescriptor.setNativeTransportMaxConcurrentConnections(nativeTransportMaxConcurrentConnections); }
+
+    public Long getNativeTransportMaxConcurrentConnectionsPerIp() { return DatabaseDescriptor.getNativeTransportMaxConcurrentConnectionsPerIp(); }
+    public void setNativeTransportMaxConcurrentConnectionsPerIp(Long nativeTransportMaxConcurrentConnections) { DatabaseDescriptor.setNativeTransportMaxConcurrentConnectionsPerIp(nativeTransportMaxConcurrentConnections); }
+
     public void reloadTriggerClasses() { TriggerExecutor.instance.reloadClasses(); }
 
-    
     public long getReadRepairAttempted() {
         return ReadRepairMetrics.attempted.count();
     }

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -95,6 +95,9 @@ public interface StorageProxyMBean
     public Long getTruncateRpcTimeout();
     public void setTruncateRpcTimeout(Long timeoutInMillis);
 
+    public void setNativeTransportMaxConcurrentConnections(Long nativeTransportMaxConcurrentConnections);
+    public Long getNativeTransportMaxConcurrentConnections();
+
     public void reloadTriggerClasses();
 
     public long getReadRepairAttempted();

--- a/src/java/org/apache/cassandra/service/pager/AbstractQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/AbstractQueryPager.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.service.pager;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -215,7 +214,7 @@ abstract class AbstractQueryPager implements QueryPager
         {
             Row first = rows.get(i++);
             firstKey = first.key;
-            firstCf = first.cf.cloneMeShallow();
+            firstCf = first.cf.cloneMeShallow(isReversed());
             toDiscard -= isReversed()
                        ? discardLast(first.cf, toDiscard, firstCf)
                        : discardFirst(first.cf, toDiscard, firstCf);
@@ -255,7 +254,7 @@ abstract class AbstractQueryPager implements QueryPager
         {
             Row last = rows.get(i--);
             lastKey = last.key;
-            lastCf = last.cf.cloneMeShallow();
+            lastCf = last.cf.cloneMeShallow(isReversed());
             toDiscard -= isReversed()
                        ? discardFirst(last.cf, toDiscard, lastCf)
                        : discardLast(last.cf, toDiscard, lastCf);

--- a/src/java/org/apache/cassandra/streaming/StreamManager.java
+++ b/src/java/org/apache/cassandra/streaming/StreamManager.java
@@ -63,17 +63,17 @@ public class StreamManager implements StreamManagerMBean
 
     public static class StreamRateLimiter
     {
-        private static final double ONE_MEGA_BIT = 1024 * 1024 * 8;
+        private static final double BYTES_PER_MEGABIT = 1024 * 1024 / 8;
         private static final RateLimiter limiter = RateLimiter.create(Double.MAX_VALUE);
         private static final RateLimiter interDCLimiter = RateLimiter.create(Double.MAX_VALUE);
         private final boolean isLocalDC;
 
         public StreamRateLimiter(InetAddress peer)
         {
-            double throughput = ((double) DatabaseDescriptor.getStreamThroughputOutboundMegabitsPerSec()) * ONE_MEGA_BIT;
+            double throughput = ((double) DatabaseDescriptor.getStreamThroughputOutboundMegabitsPerSec()) * BYTES_PER_MEGABIT;
             mayUpdateThroughput(throughput, limiter);
 
-            double interDCThroughput = ((double) DatabaseDescriptor.getInterDCStreamThroughputOutboundMegabitsPerSec()) * ONE_MEGA_BIT;
+            double interDCThroughput = ((double) DatabaseDescriptor.getInterDCStreamThroughputOutboundMegabitsPerSec()) * BYTES_PER_MEGABIT;
             mayUpdateThroughput(interDCThroughput, interDCLimiter);
 
             if (DatabaseDescriptor.getLocalDataCenter() != null && DatabaseDescriptor.getEndpointSnitch() != null)

--- a/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
@@ -22,6 +22,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
+
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.io.sstable.SSTableReader;
 import org.apache.cassandra.streaming.messages.OutgoingFileMessage;
@@ -91,8 +94,22 @@ public class StreamTransferTask extends StreamTask
             future.cancel(false);
         timeoutTasks.clear();
 
+        Throwable fail = null;
         for (OutgoingFileMessage file : files.values())
-            file.sstable.releaseReference();
+        {
+            try
+            {
+                file.sstable.releaseReference();
+            }
+            catch (Throwable t)
+            {
+                if (fail == null) fail = t;
+                else fail.addSuppressed(t);
+            }
+        }
+        files.clear();
+        if (fail != null)
+            Throwables.propagate(fail);
     }
 
     public synchronized int getTotalNumberOfFiles()

--- a/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
+++ b/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.Schema;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.LeveledManifest;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTableReader;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Create a decent leveling for the given keyspace/column family
+ *
+ * Approach is to sort the sstables by their last token
+ *
+ * given an original leveling like this (note that [ ] indicates token boundaries, not sstable size on disk, all sstables are the same size)
+ *
+ * L3 [][][][][][][][][][][]
+ * L2 [    ][    ][    ][  ]
+ * L1 [          ][        ]
+ * L0 [                    ]
+ *
+ * Will look like this after being dropped to L0 and sorted by last token (and, to illustrate overlap, the overlapping ones are put on a new line):
+ *
+ * [][][]
+ * [    ][][][]
+ *       [    ]
+ * [          ]
+ *...
+ *
+ * Then, we start iterating from the smallest last-token and adding all sstables that do not cause an overlap to
+ * a level, we will reconstruct the original leveling top-down. Whenever we add an sstable to the level, we remove it from
+ * the sorted list. Once we reach the end of the sorted list, we have a full level, and can start over with the level below.
+ *
+ * If we end up with more levels than expected, we put all levels exceeding the expected in L0, for example, original L0
+ * files will most likely be put in a level of its own since they most often overlap many other sstables
+ */
+public class SSTableOfflineRelevel
+{
+    /**
+     * @param args a list of sstables whose metadata we are changing
+     */
+    public static void main(String[] args) throws IOException
+    {
+        PrintStream out = System.out;
+        if (args.length < 2)
+        {
+            out.println("This command should be run with Cassandra stopped!");
+            out.println("Usage: sstableofflinerelevel [--dry-run] <keyspace> <columnfamily>");
+            System.exit(1);
+        }
+        boolean dryRun = args[0].equals("--dry-run");
+        String keyspace = args[args.length - 2];
+        String columnfamily = args[args.length - 1];
+        DatabaseDescriptor.loadSchemas();
+
+        if (Schema.instance.getCFMetaData(keyspace, columnfamily) == null)
+            throw new IllegalArgumentException(String.format("Unknown keyspace/columnFamily %s.%s",
+                    keyspace,
+                    columnfamily));
+
+        Keyspace.openWithoutSSTables(keyspace);
+        Directories directories = Directories.create(keyspace, columnfamily);
+        Set<SSTableReader> sstables = new HashSet<>();
+        for (Map.Entry<Descriptor, Set<Component>> sstable : directories.sstableLister().list().entrySet())
+        {
+            if (sstable.getKey() != null)
+            {
+                SSTableReader reader = SSTableReader.open(sstable.getKey());
+                sstables.add(reader);
+            }
+        }
+        if (sstables.isEmpty())
+        {
+            out.println("No sstables to relevel for "+keyspace+"."+columnfamily);
+            System.exit(1);
+        }
+        Relevel rl = new Relevel(sstables);
+        rl.relevel(dryRun);
+        System.exit(0);
+
+    }
+
+    private static class Relevel
+    {
+        private final Set<SSTableReader> sstables;
+        private final int approxExpectedLevels;
+        public Relevel(Set<SSTableReader> sstables)
+        {
+            this.sstables = sstables;
+            approxExpectedLevels = (int) Math.ceil(Math.log10(sstables.size()));
+        }
+
+        public void relevel(boolean dryRun) throws IOException
+        {
+            List<SSTableReader> sortedSSTables = new ArrayList<>(sstables);
+            Collections.sort(sortedSSTables, new Comparator<SSTableReader>()
+            {
+                @Override
+                public int compare(SSTableReader o1, SSTableReader o2)
+                {
+                    return o1.last.compareTo(o2.last);
+                }
+            });
+
+            List<List<SSTableReader>> levels = new ArrayList<>();
+
+            while (!sortedSSTables.isEmpty())
+            {
+                Iterator<SSTableReader> it = sortedSSTables.iterator();
+                List<SSTableReader> level = new ArrayList<>();
+                DecoratedKey lastLast = null;
+                while (it.hasNext())
+                {
+                    SSTableReader sstable = it.next();
+                    if (lastLast == null || lastLast.compareTo(sstable.first) < 0)
+                    {
+                        level.add(sstable);
+                        lastLast = sstable.last;
+                        it.remove();
+                    }
+                }
+                levels.add(level);
+            }
+            List<SSTableReader> l0 = new ArrayList<>();
+            if (approxExpectedLevels < levels.size())
+            {
+                for (int i = approxExpectedLevels; i < levels.size(); i++)
+                    l0.addAll(levels.get(i));
+                levels = levels.subList(0, approxExpectedLevels);
+            }
+            if (dryRun)
+                System.out.println("Potential leveling: ");
+            else
+                System.out.println("New leveling: ");
+
+            System.out.println("L0="+l0.size());
+            for (int i = levels.size() - 1; i >= 0; i--)
+                System.out.println(String.format("L%d %d", levels.size() - i, levels.get(i).size()));
+
+            if (!dryRun)
+            {
+                for (SSTableReader sstable : l0)
+                {
+                    if (sstable.getSSTableLevel() != 0)
+                        LeveledManifest.mutateLevel(Pair.create(sstable.getSSTableMetadata(), sstable.getAncestors()), sstable.descriptor, sstable.descriptor.filenameFor(Component.STATS), 0);
+                }
+                for (int i = levels.size() - 1; i >= 0; i--)
+                {
+                    for (SSTableReader sstable : levels.get(i))
+                    {
+                        int newLevel = levels.size() - i;
+                        if (newLevel != sstable.getSSTableLevel())
+                            LeveledManifest.mutateLevel(Pair.create(sstable.getSSTableMetadata(), sstable.getAncestors()), sstable.descriptor, sstable.descriptor.filenameFor(Component.STATS), newLevel);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/transport/ConnectionLimitHandler.java
+++ b/src/java/org/apache/cassandra/transport/ConnectionLimitHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.transport;
+
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * {@link SimpleChannelUpstreamHandler} implementation which allows to limit the number of concurrent
+ * connections to the Server. Be aware this <strong>MUST</strong> be shared between all child channels.
+ */
+@ChannelHandler.Sharable
+final class ConnectionLimitHandler extends SimpleChannelUpstreamHandler
+{
+    private static final Logger logger = LoggerFactory.getLogger(ConnectionLimitHandler.class);
+    private final ConcurrentMap<InetAddress, AtomicLong> connectionsPerClient = new ConcurrentHashMap<>();
+    private final AtomicLong counter = new AtomicLong(0);
+
+    @Override
+    public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent event) throws Exception
+    {
+        final long count = counter.incrementAndGet();
+        long limit = DatabaseDescriptor.getNativeTransportMaxConcurrentConnections();
+        // Setting the limit to -1 disables it.
+        if(limit < 0)
+        {
+            limit = Long.MAX_VALUE;
+        }
+        if (count > limit)
+        {
+            // The decrement will be done in channelClosed(...)
+            logger.warn("Exceeded maximum native connection limit of {} by using {} connections", limit, count);
+            ctx.getChannel().close();
+        }
+        else
+        {
+            long perIpLimit = DatabaseDescriptor.getNativeTransportMaxConcurrentConnectionsPerIp();
+            if (perIpLimit > 0)
+            {
+                InetAddress address = ((InetSocketAddress) ctx.getChannel().getRemoteAddress()).getAddress();
+
+                AtomicLong perIpCount = connectionsPerClient.get(address);
+                if (perIpCount == null)
+                {
+                    perIpCount = new AtomicLong(0);
+
+                    AtomicLong old = connectionsPerClient.putIfAbsent(address, perIpCount);
+                    if (old != null)
+                    {
+                        perIpCount = old;
+                    }
+                }
+                if (perIpCount.incrementAndGet() > perIpLimit)
+                {
+                    // The decrement will be done in channelClosed(...)
+                    logger.warn("Exceeded maximum native connection limit per ip of {} by using {} connections", perIpLimit, perIpCount);
+                    ctx.getChannel().close();
+                    return;
+                }
+            }
+            super.channelOpen(ctx, event);
+        }
+    }
+
+    @Override
+    public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent event) throws Exception
+    {
+        counter.decrementAndGet();
+        InetAddress address = ((InetSocketAddress) ctx.getChannel().getRemoteAddress()).getAddress();
+
+        AtomicLong count = connectionsPerClient.get(address);
+        if (count != null)
+        {
+            if (count.decrementAndGet() <= 0)
+            {
+                connectionsPerClient.remove(address);
+            }
+        }
+        super.channelClosed(ctx, event);
+    }
+}

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -240,6 +240,7 @@ public class Server implements CassandraDaemon.Server
         private static final Frame.Compressor frameCompressor = new Frame.Compressor();
         private static final Frame.Encoder frameEncoder = new Frame.Encoder();
         private static final Message.Dispatcher dispatcher = new Message.Dispatcher();
+        private static final ConnectionLimitHandler connectionLimitHandler = new ConnectionLimitHandler();
 
         private final Server server;
 
@@ -251,6 +252,14 @@ public class Server implements CassandraDaemon.Server
         public ChannelPipeline getPipeline() throws Exception
         {
             ChannelPipeline pipeline = Channels.pipeline();
+
+            // Add the ConnectionLimitHandler to the pipeline if configured to do so.
+            if (DatabaseDescriptor.getNativeTransportMaxConcurrentConnections() > 0
+                    || DatabaseDescriptor.getNativeTransportMaxConcurrentConnectionsPerIp() > 0)
+            {
+                // Add as first to the pipeline so the limit is enforced as first action.
+                pipeline.addFirst("connectionLimitHandler", connectionLimitHandler);
+            }
 
             //pipeline.addLast("debug", new LoggingHandler());
 

--- a/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.transport.messages;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.slf4j.Logger;
@@ -243,7 +244,8 @@ public class ErrorMessage extends Message.Response
         return new WrappedException(t, streamId);
     }
 
-    private static class WrappedException extends RuntimeException
+    @VisibleForTesting
+    public static class WrappedException extends RuntimeException
     {
         private final int streamId;
 
@@ -251,6 +253,11 @@ public class ErrorMessage extends Message.Response
         {
             super(cause);
             this.streamId = streamId;
+        }
+
+        public int getStreamId()
+        {
+            return this.streamId;
         }
     }
 

--- a/test/unit/org/apache/cassandra/cql3/SelectWithTokenFunctionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/SelectWithTokenFunctionTest.java
@@ -47,6 +47,7 @@ public class SelectWithTokenFunctionTest
         executeSchemaChange("CREATE TABLE IF NOT EXISTS %s.single_partition (a int PRIMARY KEY, b text)");
         executeSchemaChange("CREATE TABLE IF NOT EXISTS %s.compound_partition (a int, b text, PRIMARY KEY ((a, b)))");
         executeSchemaChange("CREATE TABLE IF NOT EXISTS %s.single_clustering (a int, b text, PRIMARY KEY (a, b))");
+        executeSchemaChange("CREATE TABLE IF NOT EXISTS %s.compound_with_clustering (a int, b int, c int, d int, PRIMARY KEY ((a, b), c, d))");
         clientState = ClientState.forInternalCalls();
     }
 
@@ -167,5 +168,15 @@ public class SelectWithTokenFunctionTest
     public void testTokenFunctionOnEachPartitionKeyColumns() throws Throwable
     {
         execute("SELECT * FROM %s.compound_partition WHERE token(a) > token(0) and token(b) > token('c')");
+    }
+
+    @Test
+    public void testTokenFunctionWithCompoundPartitionAndClusteringCols() throws Throwable
+    {
+        // just test that the queries don't error
+        execute("SELECT * FROM %s.compound_with_clustering WHERE token(a, b) > token(0, 0) AND c > 10 ALLOW FILTERING;");
+        execute("SELECT * FROM %s.compound_with_clustering WHERE c > 10 AND token(a, b) > token(0, 0) ALLOW FILTERING;");
+        execute("SELECT * FROM %s.compound_with_clustering WHERE token(a, b) > token(0, 0) AND (c, d) > (0, 0) ALLOW FILTERING;");
+        execute("SELECT * FROM %s.compound_with_clustering WHERE (c, d) > (0, 0) AND token(a, b) > token(0, 0) ALLOW FILTERING;");
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
@@ -1,0 +1,973 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.ColumnDefinition;
+import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.CFDefinition.Name;
+import org.apache.cassandra.db.ColumnFamilyType;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.CompositeType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class SelectStatementTest
+{
+    @Test
+    public void testBuildBoundWithNoRestrictions() throws Exception
+    {
+        Restriction[] restrictions = new Restriction[2];
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+    }
+
+    /**
+     * Test 'clustering_0 = 1' with only one clustering column
+     */
+    @Test
+    public void testBuildBoundWithOneEqRestrictionsAndOneClusteringColumn() throws Exception
+    {
+        ByteBuffer clustering_0 = ByteBufferUtil.bytes(1);
+        SingleColumnRestriction.EQ eq = new SingleColumnRestriction.EQ(toTerm(clustering_0), false);
+        Restriction[] restrictions = new Restriction[] { eq };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), clustering_0);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), clustering_0);
+    }
+
+    /**
+     * Test 'clustering_1 = 1' with 2 clustering columns
+     */
+    @Test
+    public void testBuildBoundWithOneEqRestrictionsAndTwoClusteringColumns() throws Exception
+    {
+        ByteBuffer clustering_0 = ByteBufferUtil.bytes(1);
+        SingleColumnRestriction.EQ eq = new SingleColumnRestriction.EQ(toTerm(clustering_0), false);
+        Restriction[] restrictions = new Restriction[] { eq, null };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), clustering_0);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0), clustering_0);
+    }
+
+    /**
+     * Test 'clustering_0 IN (1, 2, 3)' with only one clustering column
+     */
+    @Test
+    public void testBuildBoundWithOneInRestrictionsAndOneClusteringColumn() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        SingleColumnRestriction.IN in = new SingleColumnRestriction.InWithValues(toTerms(value1, value2, value3));
+        Restriction[] restrictions = new Restriction[] { in };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(3, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1);
+        assertComposite(cfDef, bounds.get(1), value2);
+        assertComposite(cfDef, bounds.get(2), value3);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(3, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1);
+        assertComposite(cfDef, bounds.get(1), value2);
+        assertComposite(cfDef, bounds.get(2), value3);
+    }
+
+    /**
+     * Test slice restriction (e.g 'clustering_0 > 1') with only one clustering column
+     */
+    @Test
+    public void testBuildBoundWithSliceRestrictionsAndOneClusteringColumn() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+
+        SingleColumnRestriction.Slice slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toTerm(value1));
+        Restriction[] restrictions = new Restriction[] { slice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toTerm(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LTE, toTerm(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value1);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LT, toTerm(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value1);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toTerm(value1));
+        slice.setBound(Relation.Type.LT, toTerm(value2));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value2);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toTerm(value1));
+        slice.setBound(Relation.Type.LTE, toTerm(value2));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value2);
+    }
+//
+    /**
+     * Test 'clustering_0 = 1 AND clustering_1 IN (1, 2, 3)' with two clustering columns
+     */
+    @Test
+    public void testBuildBoundWithEqAndInRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        SingleColumnRestriction.EQ eq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        SingleColumnRestriction.IN in = new SingleColumnRestriction.InWithValues(toTerms(value1, value2, value3));
+        Restriction[] restrictions = new Restriction[] { eq, in };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(3, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value1);
+        assertComposite(cfDef, bounds.get(1), value1, value2);
+        assertComposite(cfDef, bounds.get(2), value1, value3);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(3, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value1);
+        assertComposite(cfDef, bounds.get(1), value1, value2);
+        assertComposite(cfDef, bounds.get(2), value1, value3);
+    }
+
+    /**
+     * Test slice restriction (e.g 'clustering_0 > 1') with only one clustering column
+     */
+    @Test
+    public void testBuildBoundWithEqAndSliceRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+
+        SingleColumnRestriction.EQ eq = new SingleColumnRestriction.EQ(toTerm(value3), false);
+
+        SingleColumnRestriction.Slice slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toTerm(value1));
+        Restriction[] restrictions = new Restriction[] { eq, slice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value3, value1);
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0), value3);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toTerm(value1));
+        restrictions = new Restriction[] { eq, slice };
+
+        bounds = executeBuildBound(cfDef,restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value3, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0), value3);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LTE, toTerm(value1));
+        restrictions = new Restriction[] { eq, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value3, value1);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LT, toTerm(value1));
+        restrictions = new Restriction[] { eq, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value3, value1);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toTerm(value1));
+        slice.setBound(Relation.Type.LT, toTerm(value2));
+        restrictions = new Restriction[] { eq, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value3, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value3, value2);
+
+        slice = new SingleColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toTerm(value1));
+        slice.setBound(Relation.Type.LTE, toTerm(value2));
+        restrictions = new Restriction[] { eq, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value3, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value3, value2);
+    }
+
+    /**
+     * Test '(clustering_0, clustering_1) = (1, 2)' with two clustering column
+     */
+    @Test
+    public void testBuildBoundWithMultiEqRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        MultiColumnRestriction.EQ eq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        Restriction[] restrictions = new Restriction[] { eq, eq };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2);
+    }
+
+    /**
+     * Test '(clustering_0, clustering_1) IN ((1, 2), (2, 3))' with two clustering column
+     */
+    @Test
+    public void testBuildBoundWithMultiInRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        List<Term> terms = asList(toMultiItemTerminal(value1, value2), toMultiItemTerminal(value2, value3));
+        MultiColumnRestriction.IN in = new MultiColumnRestriction.InWithValues(terms);
+        Restriction[] restrictions = new Restriction[] { in, in };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2);
+        assertComposite(cfDef, bounds.get(1), value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2);
+        assertComposite(cfDef, bounds.get(1), value2, value3);
+    }
+
+    /**
+     * Test multi-column slice restrictions (e.g '(clustering_0) > (1)') with only one clustering column
+     */
+    @Test
+    public void testBuildBoundWithMultiSliceRestrictionsWithOneClusteringColumn() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+
+        MultiColumnRestriction.Slice slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toMultiItemTerminal(value1));
+        Restriction[] restrictions = new Restriction[] { slice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toMultiItemTerminal(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LTE, toMultiItemTerminal(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value1);
+
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LT, toMultiItemTerminal(value1));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value1);
+
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toMultiItemTerminal(value1));
+        slice.setBound(Relation.Type.LT, toMultiItemTerminal(value2));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value2);
+
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toMultiItemTerminal(value1));
+        slice.setBound(Relation.Type.LTE, toMultiItemTerminal(value2));
+        restrictions = new Restriction[] { slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value2);
+    }
+
+    /**
+     * Test multi-column slice restrictions (e.g '(clustering_0, clustering_1) > (1, 2)') with two clustering
+     * columns
+     */
+    @Test
+    public void testBuildBoundWithMultiSliceRestrictionsWithTwoClusteringColumn() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+
+        // (clustering_0, clustering1) > (1, 2)
+        MultiColumnRestriction.Slice slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toMultiItemTerminal(value1, value2));
+        Restriction[] restrictions = new Restriction[] { slice, slice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1, value2);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        // (clustering_0, clustering1) >= (1, 2)
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toMultiItemTerminal(value1, value2));
+        restrictions = new Restriction[] { slice, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1, value2);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        // (clustering_0, clustering1) <= (1, 2)
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LTE, toMultiItemTerminal(value1, value2));
+        restrictions = new Restriction[] { slice, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value1, value2);
+
+        // (clustering_0, clustering1) < (1, 2)
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.LT, toMultiItemTerminal(value1, value2));
+        restrictions = new Restriction[] { slice, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0));
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value1, value2);
+
+        // (clustering_0, clustering1) > (1, 2) AND (clustering_0) < (2)
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GT, toMultiItemTerminal(value1, value2));
+        slice.setBound(Relation.Type.LT, toMultiItemTerminal(value2));
+        restrictions = new Restriction[] { slice, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1, value2);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value2);
+
+        // (clustering_0, clustering1) >= (1, 2) AND (clustering_0, clustering1) <= (2, 1)
+        slice = new MultiColumnRestriction.Slice(false);
+        slice.setBound(Relation.Type.GTE, toMultiItemTerminal(value1, value2));
+        slice.setBound(Relation.Type.LTE, toMultiItemTerminal(value2, value1));
+        restrictions = new Restriction[] { slice, slice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1, value2);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value2, value1);
+    }
+
+    /**
+     * Test mixing single and multi equals restrictions (e.g. clustering_0 = 1 AND (clustering_1, clustering_2) = (2, 3))
+     */
+    @Test
+    public void testBuildBoundWithSingleEqAndMultiEqRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        ByteBuffer value4 = ByteBufferUtil.bytes(4);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) = (2, 3)
+        SingleColumnRestriction.EQ singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        MultiColumnRestriction.EQ multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value2, value3), false);
+        Restriction[] restrictions = new Restriction[] { singleEq, multiEq, multiEq };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+
+        // clustering_0 = 1 AND clustering_1 = 2 AND (clustering_2, clustering_3) = (3, 4)
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        SingleColumnRestriction.EQ singleEq2 = new SingleColumnRestriction.EQ(toTerm(value2), false);
+        multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value3, value4), false);
+        restrictions = new Restriction[] { singleEq, singleEq2, multiEq, multiEq };
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+
+        // (clustering_0, clustering_1) = (1, 2) AND clustering_2 = 3
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value3), false);
+        multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        restrictions = new Restriction[] { multiEq, multiEq, singleEq };
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) = (2, 3) AND clustering_3 = 4
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        singleEq2 = new SingleColumnRestriction.EQ(toTerm(value4), false);
+        multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value2, value3), false);
+        restrictions = new Restriction[] { singleEq, multiEq, multiEq, singleEq2 };
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+    }
+
+    /**
+     * Test clustering_0 = 1 AND (clustering_1, clustering_2) IN ((2, 3), (4, 5))
+     */
+    @Test
+    public void testBuildBoundWithSingleEqAndMultiINRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        ByteBuffer value4 = ByteBufferUtil.bytes(4);
+        ByteBuffer value5 = ByteBufferUtil.bytes(5);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) IN ((2, 3), (4, 5))
+        SingleColumnRestriction.EQ singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        MultiColumnRestriction.IN multiIn =
+                new MultiColumnRestriction.InWithValues(asList(toMultiItemTerminal(value2, value3),
+                                                               toMultiItemTerminal(value4, value5)));
+
+        Restriction[] restrictions = new Restriction[] { singleEq, multiIn, multiIn };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+        assertComposite(cfDef, bounds.get(1), value1, value4, value5);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+        assertComposite(cfDef, bounds.get(1), value1, value4, value5);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) IN ((2, 3))
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        multiIn = new MultiColumnRestriction.InWithValues(asList(toMultiItemTerminal(value2, value3),
+                                                                 toMultiItemTerminal(value4, value5)));
+
+        restrictions = new Restriction[] { singleEq, multiIn, multiIn };
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3);
+        assertComposite(cfDef, bounds.get(1), value1, value4, value5);
+
+        // clustering_0 = 1 AND clustering_1 = 5 AND (clustering_2, clustering_3) IN ((2, 3), (4, 5))
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        SingleColumnRestriction.EQ singleEq2 = new SingleColumnRestriction.EQ(toTerm(value5), false);
+        multiIn = new MultiColumnRestriction.InWithValues(asList(toMultiItemTerminal(value2, value3),
+                                                                 toMultiItemTerminal(value4, value5)));
+
+        restrictions = new Restriction[] { singleEq, singleEq2, multiIn, multiIn };
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value5, value2, value3);
+        assertComposite(cfDef, bounds.get(1), value1, value5, value4, value5);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value5, value2, value3);
+        assertComposite(cfDef, bounds.get(1), value1, value5, value4, value5);
+    }
+
+    /**
+     * Test mixing single equal restrictions with multi-column slice restrictions
+     * (e.g. clustering_0 = 1 AND (clustering_1, clustering_2) > (2, 3))
+     */
+    @Test
+    public void testBuildBoundWithSingleEqAndSliceRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        ByteBuffer value4 = ByteBufferUtil.bytes(4);
+        ByteBuffer value5 = ByteBufferUtil.bytes(5);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) > (2, 3)
+        SingleColumnRestriction.EQ singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        MultiColumnRestriction.Slice multiSlice = new MultiColumnRestriction.Slice(false);
+        multiSlice.setBound(Relation.Type.GT, toMultiItemTerminal(value2, value3));
+
+        Restriction[] restrictions = new Restriction[] { singleEq, multiSlice, multiSlice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0), value1);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) > (2, 3) AND (clustering_1) < (4)
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        multiSlice = new MultiColumnRestriction.Slice(false);
+        multiSlice.setBound(Relation.Type.GT, toMultiItemTerminal(value2, value3));
+        multiSlice.setBound(Relation.Type.LT, toMultiItemTerminal(value4));
+
+        restrictions = new Restriction[] { singleEq, multiSlice, multiSlice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LT, value1, value4);
+
+        // clustering_0 = 1 AND (clustering_1, clustering_2) => (2, 3) AND (clustering_1, clustering_2) <= (4, 5)
+        singleEq = new SingleColumnRestriction.EQ(toTerm(value1), false);
+        multiSlice = new MultiColumnRestriction.Slice(false);
+        multiSlice.setBound(Relation.Type.GTE, toMultiItemTerminal(value2, value3));
+        multiSlice.setBound(Relation.Type.LTE, toMultiItemTerminal(value4, value5));
+
+        restrictions = new Restriction[] { singleEq, multiSlice, multiSlice };
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GTE, value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.LTE, value1, value4, value5);
+    }
+
+    /**
+     * Test mixing multi equal restrictions with single-column slice restrictions
+     * (e.g. clustering_0 = 1 AND (clustering_1, clustering_2) > (2, 3))
+     */
+    @Test
+    public void testBuildBoundWithMultiEqAndSingleSliceRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+
+        // (clustering_0, clustering_1) = (1, 2) AND clustering_2 > 3
+        MultiColumnRestriction.EQ multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        SingleColumnRestriction.Slice singleSlice = new SingleColumnRestriction.Slice(false);
+        singleSlice.setBound(Relation.Type.GT, toTerm(value3));
+
+        Restriction[] restrictions = new Restriction[] { multiEq, multiEq, singleSlice };
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT, value1, value2, value3);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0), value1, value2);
+    }
+
+    @Test
+    public void testBuildBoundWithSeveralMultiColumnRestrictions() throws Exception
+    {
+        ByteBuffer value1 = ByteBufferUtil.bytes(1);
+        ByteBuffer value2 = ByteBufferUtil.bytes(2);
+        ByteBuffer value3 = ByteBufferUtil.bytes(3);
+        ByteBuffer value4 = ByteBufferUtil.bytes(4);
+        ByteBuffer value5 = ByteBufferUtil.bytes(5);
+
+        // (clustering_0, clustering_1) = (1, 2) AND (clustering_2, clustering_3) > (3, 4)
+        MultiColumnRestriction.EQ multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        MultiColumnRestriction.Slice multiSlice = new MultiColumnRestriction.Slice(false);
+        multiSlice.setBound(Relation.Type.GT, toMultiItemTerminal(value3, value4));
+
+        Restriction[] restrictions = new Restriction[] { multiEq, multiEq, multiSlice, multiSlice};
+        CFDefinition cfDef = createCFDefinition(restrictions.length);
+
+        List<ByteBuffer> bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertForRelationComposite(cfDef, bounds.get(0), Relation.Type.GT,value1, value2, value3, value4);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertEndOfRangeComposite(cfDef, bounds.get(0),  value1, value2);
+
+        // (clustering_0, clustering_1) = (1, 2) AND (clustering_2, clustering_3) IN ((3, 4), (4, 5))
+        multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        MultiColumnRestriction.IN multiIn =
+                new MultiColumnRestriction.InWithValues(asList(toMultiItemTerminal(value3, value4),
+                                                               toMultiItemTerminal(value4, value5)));
+
+        restrictions = new Restriction[] { multiEq, multiEq, multiIn, multiIn};
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+        assertComposite(cfDef, bounds.get(1), value1, value2, value4, value5);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(2, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+        assertComposite(cfDef, bounds.get(1), value1, value2, value4, value5);
+
+        // (clustering_0, clustering_1) = (1, 2) AND (clustering_2, clustering_3) = ((3, 4), (4, 5))
+        multiEq = new MultiColumnRestriction.EQ(toMultiItemTerminal(value1, value2), false);
+        MultiColumnRestriction.EQ multiEq2 = new MultiColumnRestriction.EQ(toMultiItemTerminal(value3, value4), false);
+
+        restrictions = new Restriction[] { multiEq, multiEq, multiEq2, multiEq2};
+        cfDef = createCFDefinition(restrictions.length);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.START);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+
+        bounds = executeBuildBound(cfDef, restrictions, Bound.END);
+        assertEquals(1, bounds.size());
+        assertComposite(cfDef, bounds.get(0), value1, value2, value3, value4);
+    }
+
+    /**
+     * Asserts that the specified composite contains the specified elements.
+     *
+     * @param cfDef the Column Family Definition
+     * @param actual the buffer to test
+     * @param elements the expected elements of the composite
+     */
+    private static void assertComposite(CFDefinition cfDef, ByteBuffer actual, ByteBuffer... elements)
+    {
+        ColumnNameBuilder builder = addElements(cfDef.getColumnNameBuilder(), elements);
+        assertArrayEquals("the composite is not the expected one:", actual.array(), builder.build().array());
+    }
+
+    /**
+     * Asserts that the specified composite is an end of range composite that contains the specified elements.
+     *
+     * @param cfDef the Column Family Definition
+     * @param actual the buffer to test
+     * @param elements the expected elements of the composite
+     */
+    private static void assertEndOfRangeComposite(CFDefinition cfDef, ByteBuffer actual, ByteBuffer... elements)
+    {
+        ColumnNameBuilder builder = addElements(cfDef.getColumnNameBuilder(), elements);
+        assertArrayEquals("the composite is not the expected one:", actual.array(), builder.buildAsEndOfRange().array());
+    }
+
+    /**
+     * Asserts that the specified composite is an end of range composite that contains the specified elements.
+     *
+     * @param cfDef the Column Family Definition
+     * @param actual the buffer to test
+     * @param elements the expected elements of the composite
+     */
+    private static void assertForRelationComposite(CFDefinition cfDef,
+                                                   ByteBuffer actual,
+                                                   Relation.Type relType,
+                                                   ByteBuffer... elements)
+    {
+        ColumnNameBuilder builder = addElements(cfDef.getColumnNameBuilder(), elements);
+        assertArrayEquals("the composite is not the expected one:", actual.array(), builder.buildForRelation(relType).array());
+    }
+
+    /**
+     * Adds all the specified elements to the specified builder.
+     *
+     * @param builder the builder to add to
+     * @param elements the elements to add
+     * @return the builder
+     */
+    private static ColumnNameBuilder addElements(ColumnNameBuilder builder, ByteBuffer... elements)
+    {
+        for (int i = 0, m = elements.length; i < m; i++)
+            builder.add(elements[i]);
+        return builder;
+    }
+
+    /**
+     * Calls the <code>SelectStatement.buildBound</code> with the specified restrictions.
+     *
+     * @param cfDef the Column Family Definition
+     * @param restrictions the restrictions
+     * @return the result from the method call to <code>SelectStatement.buildBound</code>
+     * @throws InvalidRequestException if buildBound throw an <code>Exception</code>
+     */
+    private static List<ByteBuffer> executeBuildBound(CFDefinition cfDef,
+                                                      Restriction[] restrictions,
+                                                      Bound bound) throws InvalidRequestException
+    {
+        return SelectStatement.buildBound(bound,
+                                          new ArrayList<Name>(cfDef.clusteringColumns()),
+                                          restrictions,
+                                          false,
+                                          cfDef,
+                                          cfDef.getColumnNameBuilder(),
+                                          Collections.<ByteBuffer>emptyList());
+    }
+
+    /**
+     * Creates a <code>CFDefinition</code> to be used in the tests.
+     *
+     * @param numberOfClusteringColumns the number of clustering columns
+     * @return a new a <code>CFDefinition</code> instance
+     * @throws ConfigurationException if the CFDefinition cannot be created
+     */
+    private static CFDefinition createCFDefinition(int numberOfClusteringColumns) throws ConfigurationException
+    {
+        List<AbstractType<?>> types = new ArrayList<>();
+        for (int i = 0, m = numberOfClusteringColumns; i < m; i++)
+            types.add(Int32Type.instance);
+
+        CompositeType cType = CompositeType.getInstance(types);
+        CFMetaData cfMetaData = new CFMetaData("keyspace", "test", ColumnFamilyType.Standard, cType);
+        ByteBuffer partitionKey = ByteBufferUtil.bytes("partitionKey");
+        cfMetaData.addColumnDefinition(ColumnDefinition.partitionKeyDef(partitionKey, Int32Type.instance, 0));
+
+        for (int i = 0, m = numberOfClusteringColumns; i < m; i++)
+        {
+            ByteBuffer name = ByteBufferUtil.bytes("clustering_" + i);
+            cfMetaData.addColumnDefinition(ColumnDefinition.clusteringKeyDef(name, types.get(i), i));
+        }
+        cfMetaData.rebuild();
+        return new CFDefinition(cfMetaData);
+    }
+
+    /**
+     * Converts the specified values into a <code>MultiItemTerminal</code>.
+     *
+     * @param values the values to convert.
+     * @return the term corresponding to the specified values.
+     */
+    private static Term toMultiItemTerminal(ByteBuffer... values)
+    {
+        return new Tuples.Value(values);
+    }
+
+    /**
+     * Converts the specified value into a term.
+     *
+     * @param value the value to convert.
+     * @return the term corresponding to the specified value.
+     */
+    private static Term toTerm(ByteBuffer value)
+    {
+        return new Constants.Value(value);
+    }
+
+    /**
+     * Converts the specified values into a <code>List</code> of terms.
+     *
+     * @param values the values to convert.
+     * @return a <code>List</code> of terms corresponding to the specified values.
+     */
+    private static List<Term> toTerms(ByteBuffer... values)
+    {
+        List<Term> terms = new ArrayList<>();
+        for (ByteBuffer value : values)
+            terms.add(toTerm(value));
+        return terms;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/DateTieredCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/DateTieredCompactionStrategyTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db.compaction;
 
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
@@ -91,6 +92,36 @@ public class DateTieredCompactionStrategyTest extends SchemaLoader
         options.put("bad_option", "1.0");
         unvalidated = validateOptions(options);
         assertTrue(unvalidated.containsKey("bad_option"));
+    }
+
+    @Test
+    public void testTimeConversions()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put(DateTieredCompactionStrategyOptions.BASE_TIME_KEY, "30");
+        options.put(DateTieredCompactionStrategyOptions.TIMESTAMP_RESOLUTION_KEY, "SECONDS");
+
+        DateTieredCompactionStrategyOptions opts = new DateTieredCompactionStrategyOptions(options);
+        assertEquals(opts.maxSSTableAge, TimeUnit.SECONDS.convert(365, TimeUnit.DAYS));
+
+        options.put(DateTieredCompactionStrategyOptions.TIMESTAMP_RESOLUTION_KEY, "MILLISECONDS");
+        opts = new DateTieredCompactionStrategyOptions(options);
+        assertEquals(opts.maxSSTableAge, TimeUnit.MILLISECONDS.convert(365, TimeUnit.DAYS));
+
+        options.put(DateTieredCompactionStrategyOptions.TIMESTAMP_RESOLUTION_KEY, "MICROSECONDS");
+        options.put(DateTieredCompactionStrategyOptions.MAX_SSTABLE_AGE_KEY, "10");
+        opts = new DateTieredCompactionStrategyOptions(options);
+        assertEquals(opts.maxSSTableAge, TimeUnit.MICROSECONDS.convert(10, TimeUnit.DAYS));
+
+        options.put(DateTieredCompactionStrategyOptions.MAX_SSTABLE_AGE_KEY, "0.5");
+        opts = new DateTieredCompactionStrategyOptions(options);
+        assertEquals(opts.maxSSTableAge, TimeUnit.MICROSECONDS.convert(1, TimeUnit.DAYS) / 2);
+
+        options.put(DateTieredCompactionStrategyOptions.TIMESTAMP_RESOLUTION_KEY, "HOURS");
+        options.put(DateTieredCompactionStrategyOptions.MAX_SSTABLE_AGE_KEY, "0.5");
+        opts = new DateTieredCompactionStrategyOptions(options);
+        assertEquals(opts.maxSSTableAge, 12);
+
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/hadoop/AbstractColumnFamilyInputFormatTest.java
+++ b/test/unit/org/apache/cassandra/hadoop/AbstractColumnFamilyInputFormatTest.java
@@ -1,0 +1,74 @@
+package org.apache.cassandra.hadoop;
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+public final class AbstractColumnFamilyInputFormatTest
+{
+    @Test
+    public void test_collectSplits()
+    {
+        String partitionerName = Murmur3Partitioner.class.getSimpleName();
+        Configuration conf = new Configuration();
+        ConfigHelper.setInputPartitioner(conf, partitionerName);
+        IPartitioner partitioner = ConfigHelper.getInputPartitioner(conf);
+        List<ColumnFamilySplit> splits = new ArrayList<>();
+        for (int i = 0 ; i < 25600 ; ++i)
+        {
+            String[] dataNodes = new String[]
+            {
+                "host-" + (i%100),
+                "host-" + (i%100)+1,
+                "host-" + (i%100)+2
+            };
+
+            Range<Token> dhtRange = new Range<>(partitioner.getTokenFactory().fromString("" + i),
+                                                partitioner.getTokenFactory().fromString("" + (i+1)),
+                                                partitioner);
+
+            ColumnFamilySplit split = new ColumnFamilySplit(Collections.singletonList(dhtRange),
+                                                            1,
+                                                            dataNodes,
+                                                            partitionerName);
+
+            splits.add(split);
+        }
+        List<InputSplit> collected = AbstractColumnFamilyInputFormat.collectSplits(splits, conf);
+        assert 100 == collected.size();
+        for (InputSplit split : collected)
+        {
+            assert 256 == ((ColumnFamilySplit)split).getTokenRanges().size();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/hadoop/ColumnFamilySplitTest.java
+++ b/test/unit/org/apache/cassandra/hadoop/ColumnFamilySplitTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.hadoop;
+
+import java.util.List;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.thrift.CfSplit;
+
+
+public final class ColumnFamilySplitTest
+{
+
+    @Test
+    public void test_serialization() throws UnknownHostException, IOException
+    {
+        IPartitioner partitioner = new RandomPartitioner();
+        Token.TokenFactory factory = partitioner.getTokenFactory();
+
+        String[] endpoints = new String[]
+        {
+            "localhost-1",
+            "localhost-2",
+            "localhost-3"
+        };
+
+        CfSplit subSplit = new CfSplit("2", "3", Long.MAX_VALUE);
+        Token left = factory.fromString(subSplit.getStart_token());
+        Token right = factory.fromString(subSplit.getEnd_token());
+        Range<Token> range = new Range<>(left, right, partitioner);
+        List<Range<Token>> ranges = range.isWrapAround() ? range.unwrap() : ImmutableList.of(range);
+
+        ColumnFamilySplit pre = new ColumnFamilySplit(
+                                    ranges,
+                                    subSplit.getRow_count(),
+                                    endpoints,
+                                    partitioner.getClass().getName());
+
+        File file = getOutput("test-serialization");
+        try (DataOutputStream out = new DataOutputStream(new FileOutputStream(file)))
+        {
+            pre.write(out);
+        }
+
+        try (DataInputStream in = new DataInputStream(new FileInputStream(file)))
+        {
+            ColumnFamilySplit post = ColumnFamilySplit.read(in);
+
+            assert pre.getLength() == post.getLength();
+            assert pre.getLocations().length == post.getLocations().length;
+            for (int i = 0 ; i < pre.getLocations().length ; ++i)
+            {
+                assert pre.getLocations()[i].equals(post.getLocations()[i]);
+            }
+            assert pre.getTokenRanges().size() == post.getTokenRanges().size();
+            for (int i = 0 ; i < pre.getTokenRanges().size() ; ++i)
+            {
+                assert pre.getTokenRanges().get(i).equals(post.getTokenRanges().get(i));
+            }
+        }
+    }
+
+    private static File getOutput(String name) throws IOException
+    {
+        File f = File.createTempFile(ColumnFamilySplit.class.getName() + '.' + name, ".db");
+        assert f.exists() : f.getPath();
+        return f;
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterClientTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterClientTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.google.common.io.Files;
+
+import org.junit.*;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.io.util.FileUtils;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertTrue;
+
+public class CQLSSTableWriterClientTest
+{
+    private File testDirectory;
+
+    @Before
+    public void setUp()
+    {
+        this.testDirectory = Files.createTempDir();
+    }
+
+    @After
+    public void tearDown()
+    {
+        FileUtils.deleteRecursive(this.testDirectory);
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception
+    {
+        Config.setClientMode(false);
+    }
+
+    @Test
+    public void testWriterInClientMode() throws IOException, InvalidRequestException
+    {
+        final String TABLE1 = "table1";
+        final String TABLE2 = "table2";
+
+        String schema = "CREATE TABLE client_test.%s ("
+                            + "  k int PRIMARY KEY,"
+                            + "  v1 text,"
+                            + "  v2 int"
+                            + ")";
+        String insert = "INSERT INTO client_test.%s (k, v1, v2) VALUES (?, ?, ?)";
+
+        CQLSSTableWriter writer = CQLSSTableWriter.builder()
+                                                  .inDirectory(this.testDirectory)
+                                                  .forTable(String.format(schema, TABLE1))
+                                                  .using(String.format(insert, TABLE1)).build();
+
+        CQLSSTableWriter writer2 = CQLSSTableWriter.builder()
+                                                   .inDirectory(this.testDirectory)
+                                                   .forTable(String.format(schema, TABLE2))
+                                                   .using(String.format(insert, TABLE2)).build();
+
+        writer.addRow(0, "A", 0);
+        writer2.addRow(0, "A", 0);
+        writer.addRow(1, "B", 1);
+        writer2.addRow(1, "B", 1);
+        writer.close();
+        writer2.close();
+
+        assertContainsDataFiles(this.testDirectory, "client_test-table1", "client_test-table2");
+    }
+
+    /**
+     * Checks that the specified directory contains the files with the specified prefixes.
+     *
+     * @param directory the directory containing the data files
+     * @param prefixes the file prefixes
+     */
+    private static void assertContainsDataFiles(File directory, String... prefixes)
+    {
+        FilenameFilter filter = new FilenameFilter()
+        {
+            @Override
+            public boolean accept(File dir, String name)
+            {
+                return name.endsWith("-Data.db");
+            }
+        };
+
+        File[] dataFiles = directory.listFiles(filter);
+        Arrays.sort(dataFiles);
+
+        assertEquals(dataFiles.length, prefixes.length);
+        for (int i = 0; i < dataFiles.length; i++)
+            assertTrue(dataFiles[i].toString().contains(prefixes[i]));
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -25,23 +25,24 @@ import java.util.Iterator;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
+
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
-import org.apache.cassandra.SchemaLoader;
-import org.apache.cassandra.Util;
 import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Schema;
-import org.apache.cassandra.cql3.*;
-import org.apache.cassandra.db.*;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.OutputHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class CQLSSTableWriterTest
 {
@@ -49,6 +50,12 @@ public class CQLSSTableWriterTest
     public static void setup() throws Exception
     {
         StorageService.instance.initServer();
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        Config.setClientMode(false);
     }
 
     @Test
@@ -176,12 +183,12 @@ public class CQLSSTableWriterTest
         @Override
         public void run()
         {
-            String schema = "CREATE TABLE cql_keyspace.table2 ("
+            String schema = "CREATE TABLE cql_keyspace2.table2 ("
                     + "  k int,"
                     + "  v int,"
                     + "  PRIMARY KEY (k, v)"
                     + ")";
-            String insert = "INSERT INTO cql_keyspace.table2 (k, v) VALUES (?, ?)";
+            String insert = "INSERT INTO cql_keyspace2.table2 (k, v) VALUES (?, ?)";
             CQLSSTableWriter writer = CQLSSTableWriter.builder()
                     .inDirectory(dataDir)
                     .forTable(schema)
@@ -206,7 +213,7 @@ public class CQLSSTableWriterTest
     @Test
     public void testConcurrentWriters() throws Exception
     {
-        String KS = "cql_keyspace";
+        String KS = "cql_keyspace2";
         String TABLE = "table2";
 
         File tempdir = Files.createTempDir();
@@ -235,7 +242,7 @@ public class CQLSSTableWriterTest
         {
             public void init(String keyspace)
             {
-                for (Range<Token> range : StorageService.instance.getLocalRanges("cql_keyspace"))
+                for (Range<Token> range : StorageService.instance.getLocalRanges("cql_keyspace2"))
                     addRangeForEndpoint(range, FBUtilities.getBroadcastAddress());
                 setPartitioner(StorageService.getPartitioner());
             }
@@ -248,7 +255,7 @@ public class CQLSSTableWriterTest
 
         loader.stream().get();
 
-        UntypedResultSet rs = QueryProcessor.processInternal("SELECT * FROM cql_keyspace.table2;");
+        UntypedResultSet rs = QueryProcessor.processInternal("SELECT * FROM cql_keyspace2.table2;");
         assertEquals(threads.length * NUMBER_WRITES_IN_RUNNABLE, rs.size());
     }
 }

--- a/test/unit/org/apache/cassandra/transport/ProtocolErrorTest.java
+++ b/test/unit/org/apache/cassandra/transport/ProtocolErrorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.transport;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.HeapChannelBufferFactory;
+import org.apache.cassandra.transport.messages.ErrorMessage;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProtocolErrorTest {
+
+    @Test
+    public void testInvalidDirection() throws Exception
+    {
+        Frame.Decoder dec = new Frame.Decoder(null);
+
+        // should generate a protocol exception for using a response frame with
+        // a prepare op, ensure that it comes back with stream ID 1
+        byte[] frame = new byte[] {
+                (byte) 0x82,  // direction & version
+                0x00,  // flags
+                0x01,  // stream ID
+                0x09,  // opcode
+                0x00, 0x00, 0x00, 0x21,  // body length
+                0x00, 0x00, 0x00, 0x1b, 0x00, 0x1b, 0x53, 0x45,
+                0x4c, 0x45, 0x43, 0x54, 0x20, 0x2a, 0x20, 0x46,
+                0x52, 0x4f, 0x4d, 0x20, 0x73, 0x79, 0x73, 0x74,
+                0x65, 0x6d, 0x2e, 0x6c, 0x6f, 0x63, 0x61, 0x6c,
+                0x3b
+        };
+        ChannelBuffer buf = new HeapChannelBufferFactory().getBuffer(frame, 0, frame.length);
+        try {
+            dec.decode(null, null, buf);
+        } catch (ErrorMessage.WrappedException e) {
+            // make sure the exception has the correct stream ID
+            Assert.assertEquals(1, e.getStreamId());
+        }
+    }
+
+    @Test
+    public void testNegativeBodyLength() throws Exception
+    {
+        Frame.Decoder dec = new Frame.Decoder(null);
+
+        byte[] frame = new byte[] {
+                (byte) 0x82,  // direction & version
+                0x00,  // flags
+                0x01,  // stream ID
+                0x09,  // opcode
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,  // body length (-1)
+        };
+        ChannelBuffer buf = new HeapChannelBufferFactory().getBuffer(frame, 0, frame.length);
+        try {
+            dec.decode(null, null, buf);
+        } catch (ErrorMessage.WrappedException e) {
+            // make sure the exception has the correct stream ID
+            Assert.assertEquals(1, e.getStreamId());
+        }
+    }
+
+    @Test
+    public void testBodyLengthOverLimit() throws Exception
+    {
+        Frame.Decoder dec = new Frame.Decoder(null);
+
+        byte[] frame = new byte[] {
+                (byte) 0x82,  // direction & version
+                0x00,  // flags
+                0x01,  // stream ID
+                0x09,  // opcode
+                0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff,  // body length
+        };
+        ChannelBuffer buf = new HeapChannelBufferFactory().getBuffer(frame, 0, frame.length);
+        try {
+            dec.decode(null, null, buf);
+        } catch (ErrorMessage.WrappedException e) {
+            // make sure the exception has the correct stream ID
+            Assert.assertEquals(1, e.getStreamId());
+        }
+    }
+}

--- a/tools/bin/sstableofflinerelevel
+++ b/tools/bin/sstableofflinerelevel
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "x$CASSANDRA_INCLUDE" = "x" ]; then
+    for include in "`dirname $0`/cassandra.in.sh" \
+                   "$HOME/.cassandra.in.sh" \
+                   /usr/share/cassandra/cassandra.in.sh \
+                   /usr/local/share/cassandra/cassandra.in.sh \
+                   /opt/cassandra/cassandra.in.sh; do
+        if [ -r $include ]; then
+            . $include
+            break
+        fi
+    done
+elif [ -r $CASSANDRA_INCLUDE ]; then
+    . $CASSANDRA_INCLUDE
+fi
+
+
+# Use JAVA_HOME if set, otherwise look for java in PATH
+if [ -x $JAVA_HOME/bin/java ]; then
+    JAVA=$JAVA_HOME/bin/java
+else
+    JAVA=`which java`
+fi
+
+if [ -z $CLASSPATH ]; then
+    echo "You must set the CLASSPATH var" >&2
+    exit 1
+fi
+
+$JAVA -cp $CLASSPATH  -Dstorage-config=$CASSANDRA_CONF \
+        -Dlog4j.configuration=log4j-tools.properties \
+        org.apache.cassandra.tools.SSTableOfflineRelevel "$@"


### PR DESCRIPTION
 Rewrite ColumnFamilySplit to contain multiple token ranges,
  and CqlPagingRecordRead to support it.

 After all splits have been fetched (or "described")
  group them by "dataNodes", sort them by startToken,
  and collapse them together permitting split size.
